### PR TITLE
Revert "Change in tests "Altom" name in imports for C# package"

### DIFF
--- a/LeanTouch/Assets/Editor/AltTester_NIS_tests.cs
+++ b/LeanTouch/Assets/Editor/AltTester_NIS_tests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using AltTester.AltDriver;
+using Altom.AltDriver;
 using System.Threading;
 
 public class AltTester_NIS_tests


### PR DESCRIPTION
Reverts alttester/EXAMPLES-NewInputSystem--LeanTouch-CSharp#6